### PR TITLE
Add 3 new regex pattern to bot

### DIFF
--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -23,5 +23,8 @@ psychobabble = [
       "Erzähle mir mehr über deine Erfahrungen in {0}."]],
 
 
-
+    [r".*([Bb]omben?).*",
+     ["Zu dem Thema {0} darf ich dir als chatbot keine Antwort geben",
+      "Guter Versuch, aber nein",
+      "Ich habe leider keine Informationen zu diesem Thema"]],
 ]

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -13,4 +13,18 @@ psychobabble = [
     "Würde {0} dir denn wirklich helfen?",
     "Bist du sicher, dass du {0} brauchst?"]],
 
+    [r".*([Bb]erlin|[Pp]aris|[Ll]ondon|[Hh]amburg|[Tt]ok[iy]o).*",
+     ["Warum hast du {0} erwähnt? Hat dieser Ort eine spezielle Bedeutung für dich?",
+      "Was verbindest du mit {0}?",
+      "Erzähle mir mehr über deine Erfahrungen in {0}."]],
+
+
+    [r".*?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}).*",
+      ["Ich habe deine E-Mail-Adresse erkannt: {0}. Wie kann ich dir per E-Mail weiterhelfen?",
+        "Die E-Mail-Adresse {0} sieht gültig aus. Wie kann ich dich per E-Mail unterstützen?"]],
+
+    [r".*(bomben?).*",
+     ["Zu dem Thema {0} darf ich dir als chatbot keine Antwort geben",
+      "Guter Versuch, aber nein",
+      "Stelle deine Frage bitte nochmal anders."]]
 ]

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -13,4 +13,11 @@ psychobabble = [
     "Würde {0} dir denn wirklich helfen?",
     "Bist du sicher, dass du {0} brauchst?"]],
 
+    [r".*?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}).*",
+      ["Ich habe deine E-Mail-Adresse erkannt: {0}. Wie kann ich dir per E-Mail weiterhelfen?",
+        "Die E-Mail-Adresse {0} sieht gültig aus. Wie kann ich dich per E-Mail unterstützen?"]], 
+
+
+
+
 ]

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -17,6 +17,10 @@ psychobabble = [
       ["Ich habe deine E-Mail-Adresse erkannt: {0}. Wie kann ich dir per E-Mail weiterhelfen?",
         "Die E-Mail-Adresse {0} sieht gültig aus. Wie kann ich dich per E-Mail unterstützen?"]], 
 
+    [r".*([Bb]erlin|[Pp]aris|[Ll]ondon|[Hh]amburg|[Tt]ok[yi]o|[Bb]arcelona).*",
+     ["Warum hast du {0} erwähnt? Hat dieser Ort eine spezielle Bedeutung für dich?",
+      "Was verbindest du mit {0}?",
+      "Erzähle mir mehr über deine Erfahrungen in {0}."]],
 
 
 

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -13,18 +13,4 @@ psychobabble = [
     "Würde {0} dir denn wirklich helfen?",
     "Bist du sicher, dass du {0} brauchst?"]],
 
-    [r".*([Bb]erlin|[Pp]aris|[Ll]ondon|[Hh]amburg|[Tt]ok[iy]o).*",
-     ["Warum hast du {0} erwähnt? Hat dieser Ort eine spezielle Bedeutung für dich?",
-      "Was verbindest du mit {0}?",
-      "Erzähle mir mehr über deine Erfahrungen in {0}."]],
-
-
-    [r".*?([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}).*",
-      ["Ich habe deine E-Mail-Adresse erkannt: {0}. Wie kann ich dir per E-Mail weiterhelfen?",
-        "Die E-Mail-Adresse {0} sieht gültig aus. Wie kann ich dich per E-Mail unterstützen?"]],
-
-    [r".*(bomben?).*",
-     ["Zu dem Thema {0} darf ich dir als chatbot keine Antwort geben",
-      "Guter Versuch, aber nein",
-      "Stelle deine Frage bitte nochmal anders."]]
 ]


### PR DESCRIPTION
Hey, I added 3 more patterns to Psychobabble to improve the bot. 
The first one is to detect an email. The second one is to detect a few bigger cities. 
The last one is to detect the German word for a bomb (Bombe) to prevent the misusage of information surrounding that topic.