### PR TITLE
Added 3 new patterns to text_patterns.py

### DIFF
--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -13,4 +13,10 @@ psychobabble = [
     "Würde {0} dir denn wirklich helfen?",
     "Bist du sicher, dass du {0} brauchst?"]],
 
+    [r"[Ee]rzaehle mir (?:einen|einen weiteren) Witz",
+    ["Natürlich! Hier ist ein Witz für dich: Warum hat der Kühlschrank den Laptop nicht bezahlt? Weil er schon eine eigene Rechnung hatte!",
+     "Klar, hier ist einer: Was macht ein Clown im Büro? Faxen!",
+     "Warum hat der Mathematiker eine Brille? Weil er mit Zahlen jongliert!",
+     "Was ist grün und läuft durch den Wald? Eine Rudel Gurken!"]],
+
 ]

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -23,6 +23,11 @@ psychobabble = [
     ["Gerne erzähle ich dir mehr über {0}. Was interessiert dich daran?",
     "Was möchtest du über {0} wissen?",
     "Ich kann dir einige Informationen über {0} geben."]],
+    
+    [r"Ich will (.*)",
+    ["Warum möchtest du {0}?",
+    "Was erhoffst du dir von {0}?",
+    "Gibt es einen bestimmten Grund, warum du {0} willst?"]]
 
 
 ]

--- a/dailizabot/text_patterns.py
+++ b/dailizabot/text_patterns.py
@@ -18,5 +18,11 @@ psychobabble = [
      "Klar, hier ist einer: Was macht ein Clown im Büro? Faxen!",
      "Warum hat der Mathematiker eine Brille? Weil er mit Zahlen jongliert!",
      "Was ist grün und läuft durch den Wald? Eine Rudel Gurken!"]],
+    
+    [r"Erzaehle mir von (.*)",
+    ["Gerne erzähle ich dir mehr über {0}. Was interessiert dich daran?",
+    "Was möchtest du über {0} wissen?",
+    "Ich kann dir einige Informationen über {0} geben."]],
+
 
 ]


### PR DESCRIPTION
I have added **3 new regex-patterns** to text_patterns.py and commited the changes.

- First new pattern: A joke should be told when "Erzaehle mir einen Witz" is entered
- Second new pattern: This pattern is designed to respond when the user asks the chatbot to "Erzaehle mir von [something]."
- Third new pattern: This pattern addresses user requests starting with "Ich will [something]." It responds by asking the user to elaborate on their desire or motivation for a more interactive conversation.